### PR TITLE
Adds update_cache on apt_get

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -4,7 +4,7 @@
   tags: ['system']
   pre_tasks:
     - name: Install Debian Packages
-      apt: pkg={{ item }} state=present
+      apt: pkg={{ item }} state=present update_cache=yes
       with_items:
         - git
         - vim


### PR DESCRIPTION
To avoid error:
> stderr: E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/u/unzip/unzip_6.0-9ubuntu1.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]