### PR TITLE
Latest version of ansible complains if there is no space after colon

### DIFF
--- a/mesos_primaries.yml
+++ b/mesos_primaries.yml
@@ -12,10 +12,10 @@
       lineinfile: dest=/etc/default/haproxy regexp="^ENABLED" line="ENABLED=1"
       when: ansible_os_family == "Debian"
   roles:
-    - { role: 'ansible-java8', tags:['runtimes', 'java'], when: ansible_os_family == 'Debian' }
-    - { role: 'ansible-zookeeper', zookeeper_hosts: "{{ groups.mesos_primaries}}", tags:['zookeeper'] }
+    - { role: 'ansible-java8', tags: ['runtimes', 'java'], when: ansible_os_family == 'Debian' }
+    - { role: 'ansible-zookeeper', zookeeper_hosts: "{{ groups.mesos_primaries}}", tags: ['zookeeper'] }
     - { role: 'ansible-mesos', mesos_quorum: "2", zookeeper_hostnames: "{{ groups.mesos_primaries | join(':' + zookeeper_client_port + ',')  }}:{{ zookeeper_client_port  }}", mesos_install_mode: 'master', mesos_cluster_name: 'mlh_mesos', tags: ['mesos', 'platforms'] }
-    - { role: 'ansible-marathon', zookeeper_hostnames: "{{ groups.mesos_primaries | join(':' + zookeeper_client_port + ',')  }}:{{ zookeeper_client_port  }}",  tags:['mesos-tools'] }
+    - { role: 'ansible-marathon', zookeeper_hostnames: "{{ groups.mesos_primaries | join(':' + zookeeper_client_port + ',')  }}:{{ zookeeper_client_port  }}",  tags: ['mesos-tools'] }
     - { role: 'ansible-consul', consul_client_address: "0.0.0.0",  consul_version: "0.4.1", consul_datacenter: "sea", consul_is_server: true, consul_servers: "{{ groups.mesos_primaries  }}", consul_is_ui: true, consul_join_at_start: true }
 
 

--- a/mesos_workers.yml
+++ b/mesos_workers.yml
@@ -6,7 +6,7 @@
       lineinfile: regexp="tty" dest=/etc/sudoers/os_defaults state=absent
       tags: ['system']
   roles: 
-    - { role: 'ansible-docker', tags:['docker'] }
-    - { role: 'ansible-java8', tags:['java'], when: ansible_os_family == 'Debian' }
-    - { role: 'ansible-mesos', mesos_containerizers: "docker,mesos", zookeeper_hostnames: "{{ groups.mesos_primaries | join(':' + zookeeper_client_port + ',')  }}:{{ zookeeper_client_port  }}",  mesos_install_mode: "slave", tags: ['mesos'] }
-    - { role: 'ansible-consul', consul_version: "0.4.1", consul_client_address: "0.0.0.0", consul_is_server: false, consul_datacenter: "sea", consul_servers: "{{ groups.mesos_primaries }}", consul_join_at_start: true, tags:['consul'] }
+    - { role: 'ansible-docker', tags: ['docker'] }
+    - { role: 'ansible-java8', tags: ['java'], when: ansible_os_family == 'Debian' }
+    - { role: 'ansible-mesos', mesos_containerizers: "docker,mesos", zookeeper_hostnames: "{{ groups.mesos_primaries | join(':' + zookeeper_client_port + ',')  }}:{{ zookeeper_client_port  }}",  mesos_install_mode: "slave", tags:  ['mesos'] }
+    - { role: 'ansible-consul', consul_version: "0.4.1", consul_client_address: "0.0.0.0", consul_is_server: false, consul_datacenter: "sea", consul_servers: "{{ groups.mesos_primaries }}", consul_join_at_start: true, tags: ['consul'] }


### PR DESCRIPTION
I'm using ansible 1.9.0.1 and ansible was having a fit when there was no space after the colon, as in many of the instances of "tags".  It shouldn't break compatibility with older versions of ansible, since it is still valid yaml with the space.